### PR TITLE
防止不在线的设备获取不到onlinetime，导致程序一直重新运行

### DIFF
--- a/JDRouterPush.py
+++ b/JDRouterPush.py
@@ -250,7 +250,7 @@ def resultDisplay():
         if pointInfo.get("pluginInfo"):
             point_infos +=  "\n    - 插件状态：" + pointInfo["status"] \
                           + "\n    - 缓存大小：" + pointInfo["cache_size"]
-        point_infos +=  "\n    - 在线时间：" + pointInfo["onlineTime"] \
+        point_infos +=  "\n    - 在线时间：" + pointInfo.get("onlineTime", "---") \
                       + "\n    - 最近到期积分：" + str(recentExpireAmount) \
                       + "\n    - 最近到期时间：" + recentExpireTime \
                       + "\n    - 最近" + str(GlobalVariable.records_num) + "条记录："


### PR DESCRIPTION
如果有设备不在线，有的信息获取不到，会导致程序不停重复运行。
有两个想法：
1.获取不到的信息自动填写为占位符字符串，程序不报错，正常发送推送信息
2.设定全局重新运行次数限制，超过次数就停止，发送推送提示设备不在线

希望大佬能帮忙修改下，非常感谢您的辛勤付出，提供了这么好的工具，不知道能否交换下交流方式方便请教您一些问题？