### PR TITLE
修复非京东云官方设备/非坐享其成/坐享其成已经完成等设备报错等问题！

### DIFF
--- a/JDRouterPush.py
+++ b/JDRouterPush.py
@@ -83,15 +83,18 @@ def routerActivityInfo(mac):
         res_json = res.json()
         result = res_json["result"]
         # finishActivity = result["finishActivity"]
-        totalIncomeValue = result["routerUnderwayResult"]["totalIncomeValue"]
-        satisfiedTimes = result["routerUnderwayResult"]["satisfiedTimes"]
-        activity_info = {"mac": mac, "totalIncomeValue": totalIncomeValue, "satisfiedTimes": satisfiedTimes}
-        index = GlobalVariable.findALocation(mac)
-        if index != -1:
-            point_info = GlobalVariable.final_result["pointInfos"][index]
-            point_info.update(activity_info)
-    else:
-        print("Request routerActivityInfo failed!")
+        if result["routerUnderwayResult"] is None:
+            exit
+        else:
+            totalIncomeValue = result["routerUnderwayResult"]["totalIncomeValue"]
+            satisfiedTimes = result["routerUnderwayResult"]["satisfiedTimes"]
+            activity_info = {"mac": mac, "totalIncomeValue": totalIncomeValue, "satisfiedTimes": satisfiedTimes}
+            index = GlobalVariable.findALocation(mac)
+            if index != -1:
+                point_info = GlobalVariable.final_result["pointInfos"][index]
+                point_info.update(activity_info)
+            else:
+                print("Request routerActivityInfo failed!")
 
 
 # 收益信息


### PR DESCRIPTION
- 修复历史遗留问题，非官方设备以及非坐享其成造成的报错。(因为以前不影响使用，所以那时候懒得修)
```
Request routerActivityInfo failed!
```
- 修复坐享其成设备365天在线任务完成之后，无限重启任务问题。（其实是同一个地方的处理，只不过现在影响使用了）